### PR TITLE
Add `refresh` command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ SpiceClient client = SpiceClient.builder()
 Retries are performed for connection and system internal errors. It is the SDK user's responsibility to properly
 handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).
 
+### Spice.ai Runtime commands
+
+Currently supported only with locally running [Spice.ai OSS](https://github.com/spiceai/spiceai).
+
+#### Accelerated dataset refresh
+
+Use `refresh` method to perform [Accelerated Dataset](https://docs.spiceai.org/components/data-accelerators) refresh. See full [dataset refresh example](/src/main/java/ai/spice/example/ExampleDatasetRefreshSpiceOSS.java).
+
+```java
+SpiceClient client = SpiceClient.builder()
+    ..
+    .build();
+
+client.refresh("taxi_trips")
+
+```
+
 ## 🤝 Connect with us
 
 Use [issues](https://github.com/spiceai/spice-java/issues),  [hey@spice.ai](mailto:hey@spice.ai) or [Discord](https://discord.gg/kZnTfneP5u) to send us feedback, suggestion or if you need help installing or using the library.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).
 
 ### Spice.ai Runtime commands
 
-Currently supported only with locally running [Spice.ai OSS](https://github.com/spiceai/spiceai).
-
 #### Accelerated dataset refresh
 
 Use `refresh` method to perform [Accelerated Dataset](https://docs.spiceai.org/components/data-accelerators) refresh. See full [dataset refresh example](/src/main/java/ai/spice/example/ExampleDatasetRefreshSpiceOSS.java).

--- a/src/main/java/ai/spice/Config.java
+++ b/src/main/java/ai/spice/Config.java
@@ -34,6 +34,10 @@ public class Config {
     public static final String CLOUD_FLIGHT_ADDRESS;
     /** Local flight address */
     public static final String LOCAL_FLIGHT_ADDRESS;
+    /** Cloud HTTP address */
+    public static final String CLOUD_HTTP_ADDRESS;
+    /** Local HTTP address */
+    public static final String LOCAL_HTTP_ADDRESS;
 
     static {
         CLOUD_FLIGHT_ADDRESS = System.getenv("SPICE_FLIGHT_URL") != null ? System.getenv("SPICE_FLIGHT_URL")
@@ -41,6 +45,12 @@ public class Config {
 
         LOCAL_FLIGHT_ADDRESS = System.getenv("SPICE_FLIGHT_URL") != null ? System.getenv("SPICE_FLIGHT_URL")
                 : "http://localhost:50051";
+        
+        CLOUD_HTTP_ADDRESS = System.getenv("SPICE_HTTP_URL") != null ? System.getenv("SPICE_HTTP_URL")
+                : "https://data.spiceai.io";
+        
+        LOCAL_HTTP_ADDRESS = System.getenv("SPICE_HTTP_URL") != null ? System.getenv("SPICE_HTTP_URL")
+                : "http://localhost:8090";
     }
 
     /**
@@ -61,5 +71,25 @@ public class Config {
      */
     public static URI getCloudFlightAddressUri() throws URISyntaxException {
         return new URI(CLOUD_FLIGHT_ADDRESS);
+    }
+
+    /**
+     * Returns the local HTTP address
+     *
+     * @return URI of the local HTTP address.
+     * @throws URISyntaxException if the string could not be parsed as a URI.
+     */
+    public static URI getLocalHttpAddressUri() throws URISyntaxException {
+        return new URI(LOCAL_HTTP_ADDRESS);
+    }
+
+    /**
+     * Returns the cloud HTTP address
+     *
+     * @return URI of the cloud HTTP address.
+     * @throws URISyntaxException if the string could not be parsed as a URI.
+     */
+    public static URI getCloudHttpAddressUri() throws URISyntaxException {
+        return new URI(CLOUD_HTTP_ADDRESS);
     }
 }

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -35,6 +35,7 @@ public class SpiceClientBuilder {
     private String appId;
     private String apiKey;
     private URI flightAddress;
+    private URI httpAddress;
     private int maxRetries = 3;
 
     /**
@@ -44,6 +45,7 @@ public class SpiceClientBuilder {
      */
     SpiceClientBuilder() throws URISyntaxException {
         this.flightAddress = Config.getLocalFlightAddressUri();
+        this.httpAddress = Config.getLocalHttpAddressUri();
     }
 
     /**
@@ -57,6 +59,20 @@ public class SpiceClientBuilder {
             throw new IllegalArgumentException("flightAddress can't be null");
         }
         this.flightAddress = flightAddress;
+        return this;
+    }
+
+    /**
+     * Sets the client's HTTP address
+     * 
+     * @param httpAddress The URI of the HTTP address
+     * @return The current instance of SpiceClientBuilder for method chaining.
+     */
+    public SpiceClientBuilder withHttpAddress(URI httpAddress) {
+        if (httpAddress == null) {
+            throw new IllegalArgumentException("httpAddress can't be null");
+        }
+        this.httpAddress = httpAddress;
         return this;
     }
 
@@ -90,6 +106,7 @@ public class SpiceClientBuilder {
      */
     public SpiceClientBuilder withSpiceCloud() throws URISyntaxException {
         this.flightAddress = Config.getCloudFlightAddressUri();
+        this.httpAddress = Config.getCloudHttpAddressUri();
         return this;
     }
 
@@ -113,6 +130,6 @@ public class SpiceClientBuilder {
      * @return The SpiceClient instance
      */
     public SpiceClient build() {
-        return new SpiceClient(appId, apiKey, flightAddress, maxRetries);
+        return new SpiceClient(appId, apiKey, flightAddress, httpAddress, maxRetries);
     }
 }

--- a/src/main/java/ai/spice/example/ExampleDatasetRefreshSpiceOSS.java
+++ b/src/main/java/ai/spice/example/ExampleDatasetRefreshSpiceOSS.java
@@ -1,0 +1,63 @@
+/*
+Copyright 2024 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package ai.spice.example;
+
+import java.net.URI;
+
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import ai.spice.SpiceClient;
+
+/**
+ * Example of using SDK with Spice.ai OSS (Local)
+ * _JAVA_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED" mvn exec:java -Dexec.mainClass="ai.spice.example.ExampleDatasetRefreshSpiceOSS"
+ * 
+ * Requires local Spice OSS running. Follow the quickstart
+ * https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine.
+ */
+public class ExampleDatasetRefreshSpiceOSS {
+
+    public static void main(String[] args) {
+        try (SpiceClient client = SpiceClient.builder()
+                .withFlightAddress(URI.create("http://localhost:50051"))
+                .withHttpAddress(URI.create("http://localhost:8090"))
+                .build()) {
+
+            client.refresh("taxi_trips");
+            System.out.println("Dataset refresh triggered for taxi_trips");
+
+            System.out.println("Query taxi_trips dataset");
+            FlightStream stream = client.query("SELECT * FROM taxi_trips LIMIT 1;");
+
+            while (stream.next()) {
+                try (VectorSchemaRoot batches = stream.getRoot()) {
+                    System.out.println(batches.contentToTSVString());
+                }
+            }
+
+        } catch (Exception e) {
+            System.err.println("An unexpected error occurred: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/ai/spice/FlightQueryTest.java
+++ b/src/test/java/ai/spice/FlightQueryTest.java
@@ -31,9 +31,8 @@ import com.google.common.base.Strings;
 
 import junit.framework.TestCase;
 
-public class FlightQueryTest 
-    extends TestCase
-{
+public class FlightQueryTest
+        extends TestCase {
     public void testQuerySpiceCloudPlatform() throws ExecutionException, InterruptedException {
         try {
             String apiKey = System.getenv("API_KEY");
@@ -96,4 +95,22 @@ public class FlightQueryTest
         }
     }
 
+    public void testRefreshSpiceOSS() throws ExecutionException, InterruptedException {
+        try {
+            SpiceClient spiceClient = SpiceClient.builder()
+                    .build();
+
+            spiceClient.refresh("taxi_trips");
+
+            try {
+                spiceClient.refresh("taxi_trips_does_not_exist");
+                fail("Should throw exception when unable to refresh dataset");
+            } catch (Exception e) {
+                assertTrue("Should correctly pass response message when unable to refresh table",
+                        e.getMessage().contains("\"message\":"));
+            }
+        } catch (Exception e) {
+            fail("Should not throw exception: " + e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## 🗣 Description

Add support for the `refresh` method to the `SpiceClient` to trigger an accelerated dataset refresh. 

## 🔨 Related Issues

https://github.com/spiceai/spice-java/issues/15

## 🤔 Concerns

Implements support via existing HTTP API endpoint while gRPC support is pending review and then release: https://github.com/spiceai/spiceai/pull/2316
