### PR TITLE
Do accelerated table refresh using Spice gRPC API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <protobuf.version>3.25.4</protobuf.version>
+        <protoc.version>3.25.4</protoc.version>
+        <grpc.version>1.66.0</grpc.version>
     </properties>
     <dependencies>
         <dependency>
@@ -59,8 +62,36 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <!-- https://arrow.apache.org/docs/java/install.html#java-compatibility -->
             <plugin>
@@ -126,6 +157,25 @@
                     <!-- <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil> -->
                 </configuration>
+            </plugin>
+            <!-- compile proto file into java files. -->
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                        <goal>compile</goal>
+                        <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/ai/spice/Config.java
+++ b/src/main/java/ai/spice/Config.java
@@ -34,10 +34,6 @@ public class Config {
     public static final String CLOUD_FLIGHT_ADDRESS;
     /** Local flight address */
     public static final String LOCAL_FLIGHT_ADDRESS;
-    /** Cloud HTTP address */
-    public static final String CLOUD_HTTP_ADDRESS;
-    /** Local HTTP address */
-    public static final String LOCAL_HTTP_ADDRESS;
 
     static {
         CLOUD_FLIGHT_ADDRESS = System.getenv("SPICE_FLIGHT_URL") != null ? System.getenv("SPICE_FLIGHT_URL")
@@ -45,12 +41,6 @@ public class Config {
 
         LOCAL_FLIGHT_ADDRESS = System.getenv("SPICE_FLIGHT_URL") != null ? System.getenv("SPICE_FLIGHT_URL")
                 : "http://localhost:50051";
-        
-        CLOUD_HTTP_ADDRESS = System.getenv("SPICE_HTTP_URL") != null ? System.getenv("SPICE_HTTP_URL")
-                : "https://data.spiceai.io";
-        
-        LOCAL_HTTP_ADDRESS = System.getenv("SPICE_HTTP_URL") != null ? System.getenv("SPICE_HTTP_URL")
-                : "http://localhost:8090";
     }
 
     /**
@@ -71,25 +61,5 @@ public class Config {
      */
     public static URI getCloudFlightAddressUri() throws URISyntaxException {
         return new URI(CLOUD_FLIGHT_ADDRESS);
-    }
-
-    /**
-     * Returns the local HTTP address
-     *
-     * @return URI of the local HTTP address.
-     * @throws URISyntaxException if the string could not be parsed as a URI.
-     */
-    public static URI getLocalHttpAddressUri() throws URISyntaxException {
-        return new URI(LOCAL_HTTP_ADDRESS);
-    }
-
-    /**
-     * Returns the cloud HTTP address
-     *
-     * @return URI of the cloud HTTP address.
-     * @throws URISyntaxException if the string could not be parsed as a URI.
-     */
-    public static URI getCloudHttpAddressUri() throws URISyntaxException {
-        return new URI(CLOUD_HTTP_ADDRESS);
     }
 }

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -35,7 +35,6 @@ public class SpiceClientBuilder {
     private String appId;
     private String apiKey;
     private URI flightAddress;
-    private URI httpAddress;
     private int maxRetries = 3;
 
     /**
@@ -45,7 +44,6 @@ public class SpiceClientBuilder {
      */
     SpiceClientBuilder() throws URISyntaxException {
         this.flightAddress = Config.getLocalFlightAddressUri();
-        this.httpAddress = Config.getLocalHttpAddressUri();
     }
 
     /**
@@ -59,20 +57,6 @@ public class SpiceClientBuilder {
             throw new IllegalArgumentException("flightAddress can't be null");
         }
         this.flightAddress = flightAddress;
-        return this;
-    }
-
-    /**
-     * Sets the client's HTTP address
-     * 
-     * @param httpAddress The URI of the HTTP address
-     * @return The current instance of SpiceClientBuilder for method chaining.
-     */
-    public SpiceClientBuilder withHttpAddress(URI httpAddress) {
-        if (httpAddress == null) {
-            throw new IllegalArgumentException("httpAddress can't be null");
-        }
-        this.httpAddress = httpAddress;
         return this;
     }
 
@@ -106,7 +90,6 @@ public class SpiceClientBuilder {
      */
     public SpiceClientBuilder withSpiceCloud() throws URISyntaxException {
         this.flightAddress = Config.getCloudFlightAddressUri();
-        this.httpAddress = Config.getCloudHttpAddressUri();
         return this;
     }
 
@@ -130,6 +113,6 @@ public class SpiceClientBuilder {
      * @return The SpiceClient instance
      */
     public SpiceClient build() {
-        return new SpiceClient(appId, apiKey, flightAddress, httpAddress, maxRetries);
+        return new SpiceClient(appId, apiKey, flightAddress, maxRetries);
     }
 }

--- a/src/main/java/ai/spice/example/ExampleDatasetRefreshSpiceOSS.java
+++ b/src/main/java/ai/spice/example/ExampleDatasetRefreshSpiceOSS.java
@@ -22,8 +22,6 @@ SOFTWARE.
 
 package ai.spice.example;
 
-import java.net.URI;
-
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
@@ -40,8 +38,6 @@ public class ExampleDatasetRefreshSpiceOSS {
 
     public static void main(String[] args) {
         try (SpiceClient client = SpiceClient.builder()
-                .withFlightAddress(URI.create("http://localhost:50051"))
-                .withHttpAddress(URI.create("http://localhost:8090"))
                 .build()) {
 
             client.refresh("taxi_trips");

--- a/src/main/proto/spice.proto
+++ b/src/main/proto/spice.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option java_package = "ai.spice.proto";
+
+message AcceleratedDatasetRefreshRequest {
+  string dataset_name = 1;
+}


### PR DESCRIPTION
## 🗣 Description

Switch from Http to gRPC for the `refresh` command in the Java SDK.

SpiceSqlClient does not expose api to perform custom flight actions so we save flight client instance used by SpiceSqlClient. 

⚠️ Pending the Spice release (new gRPC API) for tests to pass.
 
## 🔨 Related Issues

Closes https://github.com/spiceai/spice-java/issues/15

