### PR TITLE
Support JDK 11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,10 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         java:
+          - version: 11
+            distribution: microsoft # OpenJDK build by Microsoft
           - version: 17
             distribution: microsoft # OpenJDK build by Microsoft
           - version: 21
             distribution: microsoft # OpenJDK build by Microsoft
+          # setup-java supports Oracle JDS 17 and later
+          # - version: 11
+          #   distribution: oracle
           - version: 17
             distribution: oracle
           - version: 21

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: 17
+          java-version: 11
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ mvn package -Dmaven.test.skip=true
 
 This library supports the following Java implementations:
 
+- OpenJDK 11
 - OpenJDK 17
 - OpenJDK 21
+- OracleJDK 11
 - OracleJDK 17
 - OracleJDK 21
 - OracleJDK 22

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         </developer>
     </developers>
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## 🗣 Description

Downgrade target Java version to 11

Also reviewed alternative approach based on Multi-release JARs, I don't think we should proceed this way at this point as we don't have a real need but it will bring additional complexity on testing, support, plus not all build tools, IDEs might fully support MRJARs.

https://www.reddit.com/r/java/comments/rzl15p/multirelease_jars_good_or_bad_idea/ 