### PR TITLE
Improve error message for unsupported protobuf version

### DIFF
--- a/src/main/java/ai/spice/SpiceClient.java
+++ b/src/main/java/ai/spice/SpiceClient.java
@@ -138,6 +138,11 @@ public class SpiceClient implements AutoCloseable {
         } catch (RetryException e) {
             Throwable err = e.getLastFailedAttempt().getExceptionCause();
             throw new ExecutionException("Failed to execute query due to error: " + err.toString(), err);
+        } catch (ExecutionException e) {
+            if (isUnsupportedProtobufVersionException(e.getCause())) {
+                throw new ExecutionException("Unsupported protobuf version has been detected. Please upgrade 'com.google.protobuf' dependency to version 3.25.x or later.", e);
+            }
+            throw e;
         }
     }
 
@@ -212,5 +217,13 @@ public class SpiceClient implements AutoCloseable {
     @Override
     public void close() throws Exception {
         this.flightClient.close();
+    }
+
+    private boolean isUnsupportedProtobufVersionException(Throwable cause) {
+        if (cause instanceof ArrayIndexOutOfBoundsException) {
+            String message = cause.getMessage();
+            return message != null && message.contains("Index 2 out of bounds for length 2");
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## 🗣 Description

Improve error message for unsupported (older) protobuf version conflicting with required one.

Note: tried several approaches to detect the Protobuf version at runtime, but they were unreliable, often returning null. As a result, I'm detecting Protobuf issues using a specific exception type and message during the query call.