### PR TITLE
Add configurable Arrow memory limit - `withArrowMemoryLimitMB`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,20 +41,14 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: mvn --% install -DskipTests=true -Dgpg.skip -B -V # tell powershell to stop parsing with --% so it doesn't error with "Unknown lifecycle phase .skip"
     
-    - name: Install Spice (https://install.spiceai.org) (Linux)
-      if: matrix.os == 'ubuntu-latest'
+    - name: Install Spice (https://install.spiceai.org) (Unix)
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         curl https://install.spiceai.org | /bin/bash
         echo "$HOME/.spice/bin" >> $GITHUB_PATH
         $HOME/.spice/bin/spice install
-    
-    - name: Install Spice (https://install.spiceai.org) (MacOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install spiceai/spiceai/spice
-        brew install spiceai/spiceai/spiced
 
     - name: install Spice (Windows)
       if: matrix.os == 'windows-latest'

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).
 
 ### Memory Configuration
 
-The `SpiceClient` uses an Arrow `RootAllocator` for managing off-heap memory. By default, it limits memory to 50% of the JVM's maximum heap size or 1GB, whichever is lower. To prevent OOM issues in constrained environments, you can limit the maximum memory:
+The `SpiceClient` uses an Arrow `RootAllocator` for managing off-heap memory. By default, it uses all available memory. You can configure the memory limit using megabytes:
 
 ```java
 SpiceClient client = SpiceClient.builder()
-    .withMaxMemory(1024 * 1024 * 1024L) // 1GB limit
+    .withMemoryLimitMB(1024) // 1GB limit
     .build();
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ SpiceClient client = SpiceClient.builder()
 Retries are performed for connection and system internal errors. It is the SDK user's responsibility to properly
 handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).
 
+### Memory Configuration
+
+The `SpiceClient` uses an Arrow `RootAllocator` for managing off-heap memory. By default, it allows unlimited memory allocation. To prevent OOM issues in constrained environments, you can limit the maximum memory:
+
+```java
+SpiceClient client = SpiceClient.builder()
+    .withMaxMemory(1024 * 1024 * 1024L) // 1GB limit
+    .build();
+```
+
+You can also set the limit via the `SPICE_MAX_MEMORY` environment variable (in bytes). If both are provided, the builder method takes precedence.
+
 ### Spice.ai Runtime commands
 
 #### Accelerated dataset refresh

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The `SpiceClient` uses an Arrow `RootAllocator` for managing off-heap memory. By
 
 ```java
 SpiceClient client = SpiceClient.builder()
-    .withMemoryLimitMB(1024) // 1GB limit
+    .withArrowMemoryLimitMB(1024) // 1GB limit
     .build();
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,15 +124,13 @@ handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).
 
 ### Memory Configuration
 
-The `SpiceClient` uses an Arrow `RootAllocator` for managing off-heap memory. By default, it allows unlimited memory allocation. To prevent OOM issues in constrained environments, you can limit the maximum memory:
+The `SpiceClient` uses an Arrow `RootAllocator` for managing off-heap memory. By default, it limits memory to 50% of the JVM's maximum heap size or 1GB, whichever is lower. To prevent OOM issues in constrained environments, you can limit the maximum memory:
 
 ```java
 SpiceClient client = SpiceClient.builder()
     .withMaxMemory(1024 * 1024 * 1024L) // 1GB limit
     .build();
 ```
-
-You can also set the limit via the `SPICE_MAX_MEMORY` environment variable (in bytes). If both are provided, the builder method takes precedence.
 
 ### Spice.ai Runtime commands
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,6 @@
             <version>2.0.16</version>
         </dependency>
         <dependency>
-            <groupId>com.github.oshi</groupId>
-            <artifactId>oshi-core</artifactId>
-            <version>6.9.1</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
             <version>2.0.16</version>
         </dependency>
         <dependency>
+            <groupId>com.github.oshi</groupId>
+            <artifactId>oshi-core</artifactId>
+            <version>6.9.1</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>

--- a/src/main/java/ai/spice/Config.java
+++ b/src/main/java/ai/spice/Config.java
@@ -94,6 +94,27 @@ public class Config {
     }
 
     /**
+     * Returns the maximum memory allocation for the Arrow RootAllocator from the
+     * SPICE_MAX_MEMORY environment variable.
+     *
+     * @return the maximum memory in bytes, or Long.MAX_VALUE if not set or invalid.
+     */
+    public static long getMaxMemory() {
+        String maxMemoryStr = System.getenv("SPICE_MAX_MEMORY");
+        if (maxMemoryStr != null && !maxMemoryStr.isEmpty()) {
+            try {
+                long maxMemory = Long.parseLong(maxMemoryStr);
+                if (maxMemory > 0) {
+                    return maxMemory;
+                }
+            } catch (NumberFormatException e) {
+                // Invalid value, fall back to default
+            }
+        }
+        return Long.MAX_VALUE;
+    }
+
+    /**
      * Returns the Spice SDK user agent for this system, including the package
      * version, system OS, version and arch.
      * 

--- a/src/main/java/ai/spice/Config.java
+++ b/src/main/java/ai/spice/Config.java
@@ -94,25 +94,6 @@ public class Config {
     }
 
     /**
-     * Returns the maximum memory allocation for the Arrow RootAllocator from the
-     * SPICE_MAX_MEMORY environment variable.
-     *
-     * @return the maximum memory in bytes, or Long.MAX_VALUE if not set or invalid.
-     */
-    public static long getMaxMemory() {
-        try {
-            String maxMemoryStr = System.getenv("SPICE_MAX_MEMORY");
-            long maxMemory = Long.parseLong(maxMemoryStr);
-            if (maxMemory > 0) {
-                return maxMemory;
-            }
-        } catch (Exception e) {
-            // Any exception, fall back to default
-        }
-        return Long.MAX_VALUE;
-    }
-
-    /**
      * Returns the Spice SDK user agent for this system, including the package
      * version, system OS, version and arch.
      * 

--- a/src/main/java/ai/spice/Config.java
+++ b/src/main/java/ai/spice/Config.java
@@ -100,16 +100,14 @@ public class Config {
      * @return the maximum memory in bytes, or Long.MAX_VALUE if not set or invalid.
      */
     public static long getMaxMemory() {
-        String maxMemoryStr = System.getenv("SPICE_MAX_MEMORY");
-        if (maxMemoryStr != null && !maxMemoryStr.isEmpty()) {
-            try {
-                long maxMemory = Long.parseLong(maxMemoryStr);
-                if (maxMemory > 0) {
-                    return maxMemory;
-                }
-            } catch (NumberFormatException e) {
-                // Invalid value, fall back to default
+        try {
+            String maxMemoryStr = System.getenv("SPICE_MAX_MEMORY");
+            long maxMemory = Long.parseLong(maxMemoryStr);
+            if (maxMemory > 0) {
+                return maxMemory;
             }
+        } catch (Exception e) {
+            // Any exception, fall back to default
         }
         return Long.MAX_VALUE;
     }

--- a/src/main/java/ai/spice/SpiceClient.java
+++ b/src/main/java/ai/spice/SpiceClient.java
@@ -213,7 +213,7 @@ public class SpiceClient implements AutoCloseable {
 
                 builder = builder.POST(HttpRequest.BodyPublishers.ofString(json));
             } else {
-                builder = builder.POST(HttpRequest.BodyPublishers.noBody());
+                builder = builder.POST(HttpRequest.BodyPublishers.ofString("{}"));
             }
 
             HttpRequest request = builder.build();

--- a/src/main/java/ai/spice/SpiceClient.java
+++ b/src/main/java/ai/spice/SpiceClient.java
@@ -61,6 +61,8 @@ import org.apache.arrow.flight.sql.FlightSqlClient;
  */
 public class SpiceClient implements AutoCloseable {
 
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+
     private String appId;
     private String apiKey;
     private URI flightAddress;
@@ -86,15 +88,19 @@ public class SpiceClient implements AutoCloseable {
      *                      application
      * @param apiKey        the API key used for authentication with Spice.ai
      *                      services
-     * @param flightAddress the URI of the flight address for connecting to Spice.ai
+     * @param flightAddress the URI of the flight address for connecting to
+     *                      Spice.ai
      *                      services
      * @param httpAddress   the URI of the Spice.ai runtime HTTP address
      * 
-     * @param maxRetries    the maximum number of connection retries for the client
+     * @param maxRetries    the maximum number of connection retries for the
+     *                      client
      * @param userAgent     the user agent string
-     * @param maxMemory     the maximum memory allocation for the Arrow RootAllocator
+     * @param memoryLimitMB the memory limit in megabytes for the Arrow
+     *                      RootAllocator
      */
-    public SpiceClient(String appId, String apiKey, URI flightAddress, URI httpAddress, int maxRetries, String userAgent, long maxMemory) {
+    public SpiceClient(String appId, String apiKey, URI flightAddress, URI httpAddress, int maxRetries,
+            String userAgent, long memoryLimitMB) {
         this.appId = appId;
         this.apiKey = apiKey;
         this.maxRetries = maxRetries;
@@ -110,7 +116,12 @@ public class SpiceClient implements AutoCloseable {
             this.flightAddress = flightAddress;
         }
 
-        Builder builder = FlightClient.builder(new RootAllocator(maxMemory), new Location(this.flightAddress));
+        // Convert megabytes to bytes for RootAllocator:
+        // https://arrow.apache.org/java/main/reference/org.apache.arrow.memory.core/org/apache/arrow/memory/RootAllocator.html
+        long memoryLimitBytes = (memoryLimitMB > Long.MAX_VALUE / BYTES_PER_MB)
+                ? Long.MAX_VALUE
+                : memoryLimitMB * BYTES_PER_MB;
+        Builder builder = FlightClient.builder(new RootAllocator(memoryLimitBytes), new Location(this.flightAddress));
 
         if (Strings.isNullOrEmpty(apiKey)) {
             this.flightClient = new FlightSqlClient(builder.build());

--- a/src/main/java/ai/spice/SpiceClient.java
+++ b/src/main/java/ai/spice/SpiceClient.java
@@ -91,8 +91,10 @@ public class SpiceClient implements AutoCloseable {
      * @param httpAddress   the URI of the Spice.ai runtime HTTP address
      * 
      * @param maxRetries    the maximum number of connection retries for the client
+     * @param userAgent     the user agent string
+     * @param maxMemory     the maximum memory allocation for the Arrow RootAllocator
      */
-    public SpiceClient(String appId, String apiKey, URI flightAddress, URI httpAddress, int maxRetries, String userAgent) {
+    public SpiceClient(String appId, String apiKey, URI flightAddress, URI httpAddress, int maxRetries, String userAgent, long maxMemory) {
         this.appId = appId;
         this.apiKey = apiKey;
         this.maxRetries = maxRetries;
@@ -108,7 +110,7 @@ public class SpiceClient implements AutoCloseable {
             this.flightAddress = flightAddress;
         }
 
-        Builder builder = FlightClient.builder(new RootAllocator(Long.MAX_VALUE), new Location(this.flightAddress));
+        Builder builder = FlightClient.builder(new RootAllocator(maxMemory), new Location(this.flightAddress));
 
         if (Strings.isNullOrEmpty(apiKey)) {
             this.flightClient = new FlightSqlClient(builder.build());

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -38,6 +38,7 @@ public class SpiceClientBuilder {
     private URI flightAddress;
     private URI httpAddress;
     private int maxRetries = 3;
+    private long maxMemory = Long.MAX_VALUE;
 
     /**
      * Constructs a new SpiceClientBuilder instance
@@ -47,6 +48,7 @@ public class SpiceClientBuilder {
     SpiceClientBuilder() throws URISyntaxException {
         this.flightAddress = Config.getLocalFlightAddressUri();
         this.httpAddress = Config.getLocalHttpAddressUri();
+        this.maxMemory = Config.getMaxMemory();
     }
 
     /**
@@ -140,11 +142,25 @@ public class SpiceClientBuilder {
     }
 
     /**
+     * Sets the maximum memory allocation for the Arrow RootAllocator.
+     *
+     * @param maxMemory The maximum memory in bytes for the RootAllocator (must be > 0)
+     * @return The current instance of SpiceClientBuilder for method chaining.
+     */
+    public SpiceClientBuilder withMaxMemory(long maxMemory) {
+        if (maxMemory <= 0) {
+            throw new IllegalArgumentException("maxMemory must be greater than 0");
+        }
+        this.maxMemory = maxMemory;
+        return this;
+    }
+
+    /**
      * Creates SpiceClient with provided parameters.
      *
      * @return The SpiceClient instance
      */
     public SpiceClient build() {
-        return new SpiceClient(appId, apiKey, flightAddress, httpAddress, maxRetries, userAgent);
+        return new SpiceClient(appId, apiKey, flightAddress, httpAddress, maxRetries, userAgent, maxMemory);
     }
 }

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -41,6 +41,19 @@ public class SpiceClientBuilder {
     private long maxMemory = Long.MAX_VALUE;
 
     /**
+     * Calculates the default maximum memory for the Arrow RootAllocator.
+     * Returns 50% of the JVM's maximum heap size or 1GB, whichever is lower.
+     *
+     * @return the default maximum memory in bytes.
+     */
+    private static long calculateDefaultMaxMemory() {
+        long jvmMaxMemory = Runtime.getRuntime().maxMemory();
+        long halfMemory = jvmMaxMemory / 2;
+        long oneGB = 1024L * 1024 * 1024;
+        return Math.min(halfMemory, oneGB);
+    }
+
+    /**
      * Constructs a new SpiceClientBuilder instance
      *
      * @throws URISyntaxException if the URI syntax is incorrect.
@@ -48,7 +61,7 @@ public class SpiceClientBuilder {
     SpiceClientBuilder() throws URISyntaxException {
         this.flightAddress = Config.getLocalFlightAddressUri();
         this.httpAddress = Config.getLocalHttpAddressUri();
-        this.maxMemory = Config.getMaxMemory();
+        this.maxMemory = calculateDefaultMaxMemory();
     }
 
     /**

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -26,8 +26,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import com.google.common.base.Strings;
-import oshi.SystemInfo;
-import oshi.hardware.GlobalMemory;
 
 /**
  * Builder class for creating instances of SpiceClient.
@@ -40,33 +38,7 @@ public class SpiceClientBuilder {
     private URI flightAddress;
     private URI httpAddress;
     private int maxRetries = 3;
-    private long maxMemory = Long.MAX_VALUE;
-
-    /**
-     * Calculates the default maximum memory for the Arrow RootAllocator.
-     * Returns 50% of the system's total physical memory or 1GB, whichever is lower.
-     * Falls back to JVM heap size if system memory cannot be determined.
-     *
-     * @return the default maximum memory in bytes.
-     */
-    private static long calculateDefaultMaxMemory() {
-        long oneGB = 1024L * 1024 * 1024;
-        try {
-            SystemInfo systemInfo = new SystemInfo();
-            GlobalMemory memory = systemInfo.getHardware().getMemory();
-            long totalMemory = memory.getTotal();
-            if (totalMemory > 0) {
-                long halfMemory = totalMemory / 2;
-                return Math.min(halfMemory, oneGB);
-            }
-        } catch (Exception e) {
-            // Fallback to JVM heap if OSHI fails
-        }
-
-        long jvmMaxMemory = Runtime.getRuntime().maxMemory();
-        long halfMemory = jvmMaxMemory / 2;
-        return Math.min(halfMemory, oneGB);
-    }
+    private long memoryLimitMB = Long.MAX_VALUE; // Default is all available memory.
 
     /**
      * Constructs a new SpiceClientBuilder instance
@@ -76,7 +48,6 @@ public class SpiceClientBuilder {
     SpiceClientBuilder() throws URISyntaxException {
         this.flightAddress = Config.getLocalFlightAddressUri();
         this.httpAddress = Config.getLocalHttpAddressUri();
-        this.maxMemory = calculateDefaultMaxMemory();
     }
 
     /**
@@ -170,16 +141,22 @@ public class SpiceClientBuilder {
     }
 
     /**
-     * Sets the maximum memory allocation for the Arrow RootAllocator.
+     * Sets the memory limit for Apache Arrow allocator in megabytes.
+     * This controls the maximum amount of off-heap memory that can be allocated
+     * for Arrow Flight operations. If not set, the allocator will use all available memory.
      *
-     * @param maxMemory The maximum memory in bytes for the RootAllocator (must be > 0)
+     * @param memoryLimitMB Maximum memory limit in megabytes. Default is all available memory.
+     *                      Must be positive.
      * @return The current instance of SpiceClientBuilder for method chaining.
+     * @throws IllegalArgumentException if memoryLimitMB is not positive
+     *
+     * @see org.apache.arrow.memory.RootAllocator
      */
-    public SpiceClientBuilder withMaxMemory(long maxMemory) {
-        if (maxMemory <= 0) {
-            throw new IllegalArgumentException("maxMemory must be greater than 0");
+    public SpiceClientBuilder withMemoryLimitMB(long memoryLimitMB) {
+        if (memoryLimitMB <= 0) {
+            throw new IllegalArgumentException("Memory limit must be positive, got: " + memoryLimitMB + " MB");
         }
-        this.maxMemory = maxMemory;
+        this.memoryLimitMB = memoryLimitMB;
         return this;
     }
 
@@ -189,6 +166,6 @@ public class SpiceClientBuilder {
      * @return The SpiceClient instance
      */
     public SpiceClient build() {
-        return new SpiceClient(appId, apiKey, flightAddress, httpAddress, maxRetries, userAgent, maxMemory);
+        return new SpiceClient(appId, apiKey, flightAddress, httpAddress, maxRetries, userAgent, memoryLimitMB);
     }
 }

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -143,19 +143,26 @@ public class SpiceClientBuilder {
     /**
      * Sets the memory limit for Apache Arrow allocator in megabytes.
      * This controls the maximum amount of off-heap memory that can be allocated
-     * for Arrow Flight operations. If not set, the allocator will use all available memory.
+     * for Arrow Flight operations. If not set, the allocator will use all available
+     * memory.
      *
-     * @param memoryLimitMB Maximum memory limit in megabytes. Default is all available memory.
+     * @param memoryLimitMB Maximum memory limit in megabytes. Default is all
+     *                      available memory.
      *                      Must be positive.
      * @return The current instance of SpiceClientBuilder for method chaining.
      * @throws IllegalArgumentException if memoryLimitMB is not positive
      *
      * @see org.apache.arrow.memory.RootAllocator
      */
-    public SpiceClientBuilder withMemoryLimitMB(long memoryLimitMB) {
+    public SpiceClientBuilder withArrowMemoryLimitMB(long memoryLimitMB) {
         if (memoryLimitMB <= 0) {
             throw new IllegalArgumentException("Memory limit must be positive, got: " + memoryLimitMB + " MB");
         }
+        if (memoryLimitMB > Long.MAX_VALUE / 1024L / 1024L) {
+            throw new IllegalArgumentException(
+                    "Memory limit is too large: " + memoryLimitMB + " MB");
+        }
+
         this.memoryLimitMB = memoryLimitMB;
         return this;
     }

--- a/src/main/java/ai/spice/SpiceClientBuilder.java
+++ b/src/main/java/ai/spice/SpiceClientBuilder.java
@@ -26,6 +26,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import com.google.common.base.Strings;
+import oshi.SystemInfo;
+import oshi.hardware.GlobalMemory;
 
 /**
  * Builder class for creating instances of SpiceClient.
@@ -42,14 +44,27 @@ public class SpiceClientBuilder {
 
     /**
      * Calculates the default maximum memory for the Arrow RootAllocator.
-     * Returns 50% of the JVM's maximum heap size or 1GB, whichever is lower.
+     * Returns 50% of the system's total physical memory or 1GB, whichever is lower.
+     * Falls back to JVM heap size if system memory cannot be determined.
      *
      * @return the default maximum memory in bytes.
      */
     private static long calculateDefaultMaxMemory() {
+        long oneGB = 1024L * 1024 * 1024;
+        try {
+            SystemInfo systemInfo = new SystemInfo();
+            GlobalMemory memory = systemInfo.getHardware().getMemory();
+            long totalMemory = memory.getTotal();
+            if (totalMemory > 0) {
+                long halfMemory = totalMemory / 2;
+                return Math.min(halfMemory, oneGB);
+            }
+        } catch (Exception e) {
+            // Fallback to JVM heap if OSHI fails
+        }
+
         long jvmMaxMemory = Runtime.getRuntime().maxMemory();
         long halfMemory = jvmMaxMemory / 2;
-        long oneGB = 1024L * 1024 * 1024;
         return Math.min(halfMemory, oneGB);
     }
 

--- a/src/test/java/ai/spice/MemoryConfigurationTest.java
+++ b/src/test/java/ai/spice/MemoryConfigurationTest.java
@@ -1,0 +1,51 @@
+package ai.spice;
+
+import junit.framework.TestCase;
+
+/**
+ * Test memory configuration functionality
+ */
+public class MemoryConfigurationTest extends TestCase {
+
+    public void testMemoryLimitMBConfiguration() throws Exception {
+        try {
+            // Test that memory limit in MB is properly configured
+            SpiceClient client = SpiceClient.builder()
+                .withMemoryLimitMB(128) // 128 MB
+                .build();
+            
+            // If we reach here without exception, the configuration worked
+            assertTrue("Memory configuration should not throw exception", true);
+            
+            client.close();
+        } catch (Exception e) {
+            // We expect some exceptions due to no local Spice instance,
+            // but not IllegalArgumentException from memory configuration
+            assertFalse("Should not throw IllegalArgumentException for valid memory config", 
+                       e instanceof IllegalArgumentException);
+        }
+    }
+
+    public void testInvalidMemoryLimitMB() throws Exception {
+        try {
+            SpiceClient.builder()
+                .withMemoryLimitMB(0) // Invalid: must be positive
+                .build();
+            fail("Should throw IllegalArgumentException for zero memory limit");
+        } catch (IllegalArgumentException e) {
+            // Expected exception
+           assertTrue("Should throw IllegalArgumentException for zero memory limit", true);
+        }
+    }
+
+    public void testNegativeMemoryLimitMB() throws Exception {
+        try {
+            SpiceClient.builder()
+                .withMemoryLimitMB(-100) // Invalid: negative
+                .build();
+            fail("Should throw IllegalArgumentException for negative memory limit");
+        } catch (IllegalArgumentException e) {
+            assertTrue("Should throw IllegalArgumentException for negative memory limit", true);
+        }
+    }
+}

--- a/src/test/java/ai/spice/MemoryConfigurationTest.java
+++ b/src/test/java/ai/spice/MemoryConfigurationTest.java
@@ -11,41 +11,70 @@ public class MemoryConfigurationTest extends TestCase {
         try {
             // Test that memory limit in MB is properly configured
             SpiceClient client = SpiceClient.builder()
-                .withMemoryLimitMB(128) // 128 MB
-                .build();
-            
+                    .withArrowMemoryLimitMB(128) // 128 MB
+                    .build();
+
             // If we reach here without exception, the configuration worked
             assertTrue("Memory configuration should not throw exception", true);
-            
+
             client.close();
         } catch (Exception e) {
-            // We expect some exceptions due to no local Spice instance,
-            // but not IllegalArgumentException from memory configuration
-            assertFalse("Should not throw IllegalArgumentException for valid memory config", 
-                       e instanceof IllegalArgumentException);
+            fail("Should not throw exception: " + e.getMessage());
         }
     }
 
     public void testInvalidMemoryLimitMB() throws Exception {
         try {
             SpiceClient.builder()
-                .withMemoryLimitMB(0) // Invalid: must be positive
-                .build();
+                    .withArrowMemoryLimitMB(0) // Invalid: must be positive
+                    .build();
             fail("Should throw IllegalArgumentException for zero memory limit");
         } catch (IllegalArgumentException e) {
             // Expected exception
-           assertTrue("Should throw IllegalArgumentException for zero memory limit", true);
+            assertTrue("Should throw IllegalArgumentException for zero memory limit", true);
         }
     }
 
     public void testNegativeMemoryLimitMB() throws Exception {
         try {
             SpiceClient.builder()
-                .withMemoryLimitMB(-100) // Invalid: negative
-                .build();
+                    .withArrowMemoryLimitMB(-100) // Invalid: negative
+                    .build();
             fail("Should throw IllegalArgumentException for negative memory limit");
         } catch (IllegalArgumentException e) {
             assertTrue("Should throw IllegalArgumentException for negative memory limit", true);
+        }
+    }
+
+    public void testOverflowProtection() throws Exception {
+        // Test overflow protection - values that would cause overflow when converted to
+        // bytes
+        long maxSafeMB = Long.MAX_VALUE / (1024L * 1024L);
+        long overflowValue = maxSafeMB + 1;
+
+        try {
+            SpiceClient.builder()
+                    .withArrowMemoryLimitMB(overflowValue) // Would cause overflow
+                    .build();
+            fail("Should throw IllegalArgumentException for overflow-causing memory limit");
+        } catch (IllegalArgumentException e) {
+            assertTrue("Should throw IllegalArgumentException for overflow protection", true);
+        }
+    }
+
+    public void testMaxSafeMemoryLimit() throws Exception {
+        // Test that the maximum safe value works without throwing
+        long maxSafeMB = Long.MAX_VALUE / (1024L * 1024L);
+
+        try {
+            SpiceClient client = SpiceClient.builder()
+                    .withArrowMemoryLimitMB(maxSafeMB) // Maximum safe value
+                    .build();
+
+            assertTrue("Maximum safe memory limit should work", true);
+            client.close();
+        } catch (Exception e) {
+            fail("Should not throw exception: " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🗣 Description

RootAllocator defaults to unlimited memory. Added a builder method and environment variable to restrict the memory usage but fallback to previous behavior if absent.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

There are possibly memory leaks related to RootAllocator such as, https://github.com/apache/arrow-java/issues/50
