### PR TITLE
Fix integration tests: Use quickstart dataset for Cloud

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -153,5 +153,5 @@ jobs:
     - name: Test
       run: mvn test -B
       env:
-        API_KEY: ${{ secrets.SPICE_CLOUD_API_KEY }}
+        API_KEY: ${{ secrets.SPICE_CLOUD_QUICKSTART_API_KEY }}
   

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: Test
       run: mvn test -B
       env:
-        API_KEY: ${{ secrets.SPICE_CLOUD_API_KEY }}
+        API_KEY: ${{ secrets.SPICE_CLOUD_QUICKSTART_API_KEY }}
 
   build:
     runs-on: ubuntu-latest

--- a/src/main/java/ai/spice/SpiceClient.java
+++ b/src/main/java/ai/spice/SpiceClient.java
@@ -200,7 +200,7 @@ public class SpiceClient implements AutoCloseable {
 
                 builder = builder.POST(HttpRequest.BodyPublishers.ofString(json));
             } else {
-                builder = builder.POST(HttpRequest.BodyPublishers.noBody());
+                builder = builder.POST(HttpRequest.BodyPublishers.ofString("{}"));
             }
 
             HttpRequest request = builder.build();

--- a/src/test/java/ai/spice/FlightQueryTest.java
+++ b/src/test/java/ai/spice/FlightQueryTest.java
@@ -46,7 +46,7 @@ public class FlightQueryTest
                     .withSpiceCloud()
                     .build();
 
-            String sql = "SELECT number, \"timestamp\", base_fee_per_gas, base_fee_per_gas / 1e9 AS base_fee_per_gas_gwei FROM eth.blocks limit 2000";
+            String sql = "SELECT tpep_pickup_datetime, total_amount, passenger_count from taxi_trips limit 10;";
             FlightStream res = spiceClient.query(sql);
 
             int totalRows = 0;
@@ -60,8 +60,8 @@ public class FlightQueryTest
                 totalRows += root.getRowCount();
             }
 
-            assertEquals("Expected column count does not match", 4, columnCount);
-            assertEquals("Expected row count does not match", 2000, totalRows);
+            assertEquals("Expected column count does not match", 3, columnCount);
+            assertEquals("Expected row count does not match", 10, totalRows);
 
         } catch (Exception e) {
             fail("Should not throw any exception: " + e.getMessage());


### PR DESCRIPTION
## 🗣 Description

1. Fix dataset refresh w/o refreshOptions specified
2. Update tests to use ` quickstart` dataset

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
