### PR TITLE
chore: Upgrade ADBC to 0.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>org.apache.arrow.adbc</groupId>
             <artifactId>adbc-driver-flight-sql</artifactId>
-            <version>0.22.0</version>
+            <version>0.23.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow.adbc</groupId>
             <artifactId>adbc-core</artifactId>
-            <version>0.22.0</version>
+            <version>0.23.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
## Summary

Bumps the ADBC Java dependencies from **0.22.0 → 0.23.0** (the latest ADBC release), used for parameterized queries via `FlightSqlDriver`:

- `org.apache.arrow.adbc:adbc-driver-flight-sql`
- `org.apache.arrow.adbc:adbc-core`

## Context — Arrow vs. DataFusion 54

This started as "upgrade Arrow to match DataFusion 54." The finding: there is no Arrow **Java** bump to make.

- DataFusion 54 depends on **arrow-rs 58** (the Spice runtime `trunk` pins `datafusion 54.0.0` + `arrow 58.0.0`).
- By the historical numbering, arrow-rs 58 ≈ umbrella Arrow "23" — but that line is C++/Python/Rust. **Apache Arrow _Java_ (`apache/arrow-java`) tops out at 19.0.0**; there is no 20+ release (20.0.0 is still a SNAPSHOT, and it also raises the min JDK to 17, which would break our Java 11 target).
- spice-java already pins `flight-sql:19.0.0` — the newest Arrow Java release — and Arrow's IPC/Flight wire format is stable, so it stays compatible with a DataFusion‑54 runtime.

So the Arrow pin is unchanged. The ADBC bump is the one genuinely-available upgrade in the Arrow ecosystem. ADBC 0.23.0 is itself built against Arrow 18.3.0 (same as 0.22.0), overridden on the classpath by the `flight-sql:19.0.0` pin, so **the effective Arrow version does not change**.

## Validation

- **Dependency tree** — before/after identical except the three `adbc-*` artifacts (0.22.0 → 0.23.0). Core Arrow all resolves to 19.0.0; the lone `flight-sql-jdbc-core:18.3.0` straggler pre-existed. No new split classpath.
- **Compile** — clean (main + test, Java 11 target).
- **Live ADBC parameterized queries** — ran `ExampleParameterizedQueries` against a local Spice runtime (`taxi_trips`, 131k rows): all four Param patterns (Float64 inference, multi-param, explicit Int64, mixed inferred + String) returned correct rows.
- **Full test suite** — 214/214 pass.

Only substantive transitive change: `protobuf-java` 4.33.2 → 4.34.1 (forward bump). CI's OWASP job will confirm no new CVE exposure.
