### PR TITLE
feat: add health, readiness, and runtime status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,48 @@ client.refresh("taxi_trips")
 
 ```
 
+#### Health, readiness, and status
+
+Use `isHealthy()` and `isReady()` to probe the runtime, and `runtimeStatus()` for
+per-component detail. See the full [health and status example](/src/main/java/ai/spice/example/ExampleHealthAndStatus.java).
+
+```java
+SpiceClient client = SpiceClient.builder()
+    ..
+    .build();
+
+// Liveness — is the runtime up? Unauthenticated.
+if (!client.isHealthy()) {
+    return;
+}
+
+// Readiness — the runtime becomes ready once its datasets have loaded, so a
+// runtime can be healthy but not yet queryable.
+while (!client.isReady()) {
+    Thread.sleep(1000);
+}
+```
+
+Both return `false` rather than throwing when the runtime is unreachable, so they can be
+polled directly in a loop.
+
+`runtimeStatus()` returns one `ConnectionDetails` per runtime connection — `http`,
+`flight`, `metrics`, and `opentelemetry` — naming which component is not ready and where
+it is bound. That makes it strictly more informative than the boolean `isReady()`:
+
+```java
+for (ConnectionDetails connection : client.runtimeStatus()) {
+    System.out.printf("%s %s %s%n",
+        connection.getName(),        // "flight"
+        connection.getEndpoint(),    // "127.0.0.1:50051"
+        connection.getStatus());     // ComponentStatus.READY
+}
+```
+
+`getStatus()` returns a `ComponentStatus` — `INITIALIZING`, `READY`, `DISABLED`, `ERROR`,
+`REFRESHING`, `SHUTTING_DOWN`, or `NOT_LOADED`. A status a newer runtime introduces maps to
+`UNKNOWN` rather than failing; `getRawStatus()` returns it verbatim.
+
 ### Logging
 
 The SDK uses SLF4J for logging, allowing you to plug in your preferred logging implementation (Logback, Log4j2, java.util.logging, etc.).

--- a/src/main/java/ai/spice/ComponentStatus.java
+++ b/src/main/java/ai/spice/ComponentStatus.java
@@ -1,0 +1,113 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package ai.spice;
+
+/**
+ * The status of a single runtime component, as reported by {@code /v1/status}.
+ *
+ * <p>
+ * The runtime serializes these as plain strings such as {@code "Ready"}. A value
+ * this SDK does not recognize maps to {@link #UNKNOWN} rather than failing, so a
+ * newer runtime can add a status without breaking an older client.
+ */
+public enum ComponentStatus {
+    /** The component is initializing and not yet ready. */
+    INITIALIZING("Initializing"),
+
+    /** The component is ready to accept connections. */
+    READY("Ready"),
+
+    /** The component is disabled and not running. */
+    DISABLED("Disabled"),
+
+    /** An error occurred in the component. */
+    ERROR("Error"),
+
+    /** The component is refreshing its state. */
+    REFRESHING("Refreshing"),
+
+    /** The component is shutting down. */
+    SHUTTING_DOWN("ShuttingDown"),
+
+    /** The component is configured but not loaded yet. */
+    NOT_LOADED("NotLoaded"),
+
+    /** A status this version of the SDK does not recognize. */
+    UNKNOWN("Unknown");
+
+    private final String wireValue;
+
+    ComponentStatus(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    /**
+     * The value the runtime uses on the wire.
+     *
+     * @return the wire representation of this status
+     */
+    public String getWireValue() {
+        return this.wireValue;
+    }
+
+    /**
+     * Maps a wire value onto a status.
+     *
+     * @param value the value the runtime reported, may be null
+     * @return the matching status, or {@link #UNKNOWN} if it is not recognized
+     */
+    public static ComponentStatus fromWireValue(String value) {
+        if (value == null) {
+            return UNKNOWN;
+        }
+        for (ComponentStatus status : values()) {
+            if (status.wireValue.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * Whether this status means the component is ready to accept connections.
+     *
+     * @return true if the component is ready
+     */
+    public boolean isReady() {
+        return this == READY;
+    }
+
+    /**
+     * Whether this status means the component is in an error state.
+     *
+     * @return true if the component errored
+     */
+    public boolean isError() {
+        return this == ERROR;
+    }
+
+    @Override
+    public String toString() {
+        return this.wireValue;
+    }
+}

--- a/src/main/java/ai/spice/ConnectionDetails.java
+++ b/src/main/java/ai/spice/ConnectionDetails.java
@@ -1,0 +1,104 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package ai.spice;
+
+/**
+ * The status of one runtime connection, as reported by {@code /v1/status}.
+ *
+ * <p>
+ * The runtime reports one of these per connection — {@code http}, {@code flight},
+ * {@code metrics}, and {@code opentelemetry}. This is strictly more informative
+ * than the boolean {@link SpiceClient#isReady()}: it names which component is not
+ * ready, and where it is bound.
+ */
+public class ConnectionDetails {
+    private final String name;
+    private final String endpoint;
+    private final String status;
+
+    /**
+     * Creates connection details.
+     *
+     * @param name     the connection name, for example {@code flight}
+     * @param endpoint where the connection is bound, or {@code N/A} when disabled
+     * @param status   the raw status the runtime reported
+     */
+    public ConnectionDetails(String name, String endpoint, String status) {
+        this.name = name;
+        this.endpoint = endpoint;
+        this.status = status;
+    }
+
+    /**
+     * The connection name — {@code http}, {@code flight}, {@code metrics}, or
+     * {@code opentelemetry}.
+     *
+     * @return the connection name
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Where the connection is bound. {@code N/A} when the component is disabled.
+     *
+     * @return the endpoint
+     */
+    public String getEndpoint() {
+        return this.endpoint;
+    }
+
+    /**
+     * The status as a {@link ComponentStatus}. A status this SDK does not
+     * recognize maps to {@link ComponentStatus#UNKNOWN}; use
+     * {@link #getRawStatus()} to read it verbatim.
+     *
+     * @return the parsed status
+     */
+    public ComponentStatus getStatus() {
+        return ComponentStatus.fromWireValue(this.status);
+    }
+
+    /**
+     * The status exactly as the runtime reported it.
+     *
+     * @return the raw status string
+     */
+    public String getRawStatus() {
+        return this.status;
+    }
+
+    /**
+     * Whether this connection is ready to accept traffic.
+     *
+     * @return true if the component is ready
+     */
+    public boolean isReady() {
+        return getStatus().isReady();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s (%s): %s", this.name, this.endpoint, this.status);
+    }
+}

--- a/src/main/java/ai/spice/SpiceClient.java
+++ b/src/main/java/ai/spice/SpiceClient.java
@@ -115,6 +115,10 @@ import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 import org.apache.arrow.flight.sql.FlightSqlClient;
 import org.slf4j.Logger;
@@ -1081,9 +1085,200 @@ public class SpiceClient implements AutoCloseable {
     }
 
     /**
+     * Checks whether the Spice runtime is healthy by calling {@code /health}.
+     *
+     * <p>
+     * This is an unauthenticated liveness probe: it reports that the runtime is
+     * up, not that it is finished loading. Use {@link #isReady()} before issuing
+     * queries.
+     *
+     * <p>
+     * Returns false rather than throwing when the runtime is unreachable, so it
+     * can be polled directly in a loop.
+     *
+     * @return true if the runtime reports healthy
+     */
+    public boolean isHealthy() {
+        return probe("/health", "ok", false);
+    }
+
+    /**
+     * Checks whether the Spice runtime is ready to accept queries by calling
+     * {@code /v1/ready}.
+     *
+     * <p>
+     * The runtime becomes ready once its datasets have loaded, so this returns
+     * false for a period after {@link #isHealthy()} first returns true. When an
+     * API key is configured it is sent, which Spice.ai Cloud requires.
+     *
+     * <p>
+     * Returns false rather than throwing when the runtime is unreachable, so it
+     * can be polled directly in a loop.
+     *
+     * @return true if the runtime reports ready
+     */
+    public boolean isReady() {
+        return probe("/v1/ready", "ready", true);
+    }
+
+    /**
+     * Sends a GET to a runtime probe endpoint and reports whether it succeeded.
+     *
+     * @param path         the endpoint path
+     * @param expectedBody the token the body must contain
+     * @param authenticate whether to send the API key, when one is configured
+     * @return true if the runtime returned 200 with the expected body
+     */
+    private boolean probe(String path, String expectedBody, boolean authenticate) {
+        try {
+            HttpRequest request = buildProbeRequest(this.httpAddress, path,
+                    authenticate ? this.apiKey : null);
+
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                logger.debug("Probe {} returned status {}", path, response.statusCode());
+                return false;
+            }
+
+            String body = response.body();
+            return body != null && body.toLowerCase().contains(expectedBody);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            logger.debug("Probe {} interrupted", path);
+            return false;
+        } catch (Exception err) {
+            logger.debug("Probe {} failed: {}", path, err.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Builds a GET request against a runtime endpoint.
+     *
+     * @param httpAddress the runtime's HTTP address
+     * @param path        the endpoint path
+     * @param apiKey      the API key to send, or null to send none
+     * @return the request
+     * @throws URISyntaxException if the resulting URI is malformed
+     */
+    static HttpRequest buildProbeRequest(URI httpAddress, String path, String apiKey)
+            throws URISyntaxException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(new URI(String.format("%s%s", httpAddress, path)))
+                .header("X-Spice-User-Agent", Config.getUserAgent())
+                .GET();
+
+        if (!Strings.isNullOrEmpty(apiKey)) {
+            builder = builder.header("X-API-Key", apiKey);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Returns the status of each runtime connection by calling
+     * {@code /v1/status}.
+     *
+     * <p>
+     * The runtime reports one {@link ConnectionDetails} per connection —
+     * {@code http}, {@code flight}, {@code metrics}, and
+     * {@code opentelemetry} — naming which component is not ready and where it is
+     * bound. That makes it strictly more informative than the boolean
+     * {@link #isReady()}.
+     *
+     * @return the status of each runtime connection
+     * @throws ExecutionException if the runtime is unreachable or returns an
+     *                            unexpected response
+     */
+    public List<ConnectionDetails> runtimeStatus() throws ExecutionException {
+        logger.debug("Fetching runtime status");
+        try {
+            HttpRequest request = buildProbeRequest(this.httpAddress, "/v1/status", this.apiKey);
+
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                logger.error("Runtime status failed - statusCode={}, response={}", response.statusCode(),
+                        response.body());
+                throw new ExecutionException(
+                        String.format("Failed to fetch runtime status. Status Code: %d, Response: %s",
+                                response.statusCode(),
+                                response.body()),
+                        null);
+            }
+
+            return parseRuntimeStatus(response.body());
+        } catch (ExecutionException e) {
+            // no need to wrap ExecutionException
+            throw e;
+        } catch (ConnectException err) {
+            logger.error("Cannot connect to Spice runtime at {}: {}", this.httpAddress, err.getMessage());
+            throw new ExecutionException(
+                    String.format("The Spice runtime is unavailable at %s. Is it running?", this.httpAddress), err);
+        } catch (InterruptedException err) {
+            Thread.currentThread().interrupt();
+            throw new ExecutionException("Interrupted while fetching runtime status", err);
+        } catch (Exception err) {
+            logger.error("Runtime status failed: {}", err.getMessage());
+            throw new ExecutionException("Failed to fetch runtime status due to error: " + err.toString(), err);
+        }
+    }
+
+    /**
+     * Parses the {@code /v1/status} response body.
+     *
+     * @param body the JSON array the runtime returned
+     * @return the parsed connection details
+     * @throws ExecutionException if the body is not a JSON array
+     */
+    static List<ConnectionDetails> parseRuntimeStatus(String body) throws ExecutionException {
+        JsonElement root;
+        try {
+            root = JsonParser.parseString(body == null ? "" : body);
+        } catch (JsonSyntaxException err) {
+            throw new ExecutionException("The runtime returned a malformed status response", err);
+        }
+
+        if (root == null || !root.isJsonArray()) {
+            throw new ExecutionException("The runtime returned an unexpected status response", null);
+        }
+
+        List<ConnectionDetails> details = new ArrayList<>();
+        for (JsonElement element : root.getAsJsonArray()) {
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject object = element.getAsJsonObject();
+            details.add(new ConnectionDetails(
+                    optionalString(object, "name"),
+                    optionalString(object, "endpoint"),
+                    optionalString(object, "status")));
+        }
+        return details;
+    }
+
+    /**
+     * Reads a string member, tolerating absent or null members.
+     *
+     * @param object the object to read from
+     * @param member the member name
+     * @return the string value, or null when absent
+     */
+    private static String optionalString(JsonObject object, String member) {
+        JsonElement element = object.get(member);
+        if (element == null || element.isJsonNull() || !element.isJsonPrimitive()) {
+            return null;
+        }
+        return element.getAsString();
+    }
+
+    /**
      * Refreshes an accelerated dataset using the configured dataset acceleration
      * settings
-     * 
+     *
      * @param dataset the name of the dataset to refresh
      * @throws ExecutionException if there is an error refreshing the dataset
      */

--- a/src/main/java/ai/spice/example/ExampleHealthAndStatus.java
+++ b/src/main/java/ai/spice/example/ExampleHealthAndStatus.java
@@ -1,0 +1,89 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package ai.spice.example;
+
+import java.net.URI;
+import java.util.List;
+
+import ai.spice.ConnectionDetails;
+import ai.spice.SpiceClient;
+
+/**
+ * Example of checking runtime health, readiness, and per-component status.
+ * _JAVA_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED" mvn exec:java
+ * -Dexec.mainClass="ai.spice.example.ExampleHealthAndStatus"
+ *
+ * Requires local Spice OSS running. Follow the quickstart
+ * https://github.com/spiceai/spiceai?tab=readme-ov-file#%EF%B8%8F-quickstart-local-machine.
+ */
+public class ExampleHealthAndStatus {
+
+    /** How long to wait for the runtime to finish loading its datasets. */
+    private static final long READY_TIMEOUT_MS = 120_000;
+
+    /** How long to wait between readiness polls. */
+    private static final long POLL_INTERVAL_MS = 1_000;
+
+    public static void main(String[] args) {
+        try (SpiceClient client = SpiceClient.builder()
+                .withFlightAddress(URI.create("grpc://localhost:50051"))
+                .withHttpAddress(URI.create("http://localhost:8090"))
+                .build()) {
+
+            // Liveness: is the runtime process up at all?
+            if (!client.isHealthy()) {
+                System.out.println("Spice runtime is not healthy. Is it running?");
+                return;
+            }
+            System.out.println("Spice runtime is healthy");
+
+            // Readiness: the runtime becomes ready once its datasets have loaded,
+            // so poll rather than assuming healthy means queryable.
+            long deadline = System.currentTimeMillis() + READY_TIMEOUT_MS;
+            while (!client.isReady()) {
+                if (System.currentTimeMillis() > deadline) {
+                    System.out.println("Timed out waiting for the runtime to become ready");
+                    return;
+                }
+                Thread.sleep(POLL_INTERVAL_MS);
+            }
+            System.out.println("Spice runtime is ready");
+
+            // Per-component detail: which connection is not ready, and where is it bound?
+            List<ConnectionDetails> status = client.runtimeStatus();
+            System.out.println("Runtime status:");
+            for (ConnectionDetails connection : status) {
+                System.out.printf("  %-14s %-24s %s%n",
+                        connection.getName(),
+                        connection.getEndpoint(),
+                        connection.getStatus());
+            }
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.out.println("Interrupted while waiting for the runtime");
+        } catch (Exception e) {
+            System.out.println("Error: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/ai/spice/RuntimeStatusTest.java
+++ b/src/test/java/ai/spice/RuntimeStatusTest.java
@@ -1,0 +1,287 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package ai.spice;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import com.sun.net.httpserver.HttpServer;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for the runtime health, readiness, and status endpoints.
+ *
+ * <p>
+ * These run against a JDK {@link HttpServer} bound to an ephemeral port, so they
+ * need no live Spice runtime.
+ */
+public class RuntimeStatusTest extends TestCase {
+
+    private HttpServer server;
+    private SpiceClient client;
+
+    /**
+     * A canned response for one path.
+     */
+    private void stub(String path, int statusCode, String body) {
+        this.server.createContext(path, exchange -> {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(statusCode, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+    }
+
+    private void startServer() throws IOException {
+        this.server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    }
+
+    private SpiceClient clientForServer(String apiKey) throws Exception {
+        this.server.start();
+        URI httpAddress = new URI("http://127.0.0.1:" + this.server.getAddress().getPort());
+        SpiceClientBuilder builder = SpiceClient.builder().withHttpAddress(httpAddress);
+        if (apiKey != null) {
+            builder = builder.withApiKey(apiKey);
+        }
+        return builder.build();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (this.client != null) {
+            this.client.close();
+            this.client = null;
+        }
+        if (this.server != null) {
+            this.server.stop(0);
+            this.server = null;
+        }
+        super.tearDown();
+    }
+
+    // ==================== isHealthy ====================
+
+    public void testIsHealthyReturnsTrueOnOk() throws Exception {
+        startServer();
+        stub("/health", 200, "ok");
+        this.client = clientForServer(null);
+
+        assertTrue("healthy runtime should report healthy", this.client.isHealthy());
+    }
+
+    public void testIsHealthyReturnsFalseOnNonOkStatus() throws Exception {
+        startServer();
+        stub("/health", 503, "unavailable");
+        this.client = clientForServer(null);
+
+        assertFalse("503 should not report healthy", this.client.isHealthy());
+    }
+
+    public void testIsHealthyReturnsFalseWhenRuntimeIsUnreachable() throws Exception {
+        // Bind a server to claim a port, then stop it so nothing is listening.
+        startServer();
+        this.client = clientForServer(null);
+        this.server.stop(0);
+        this.server = null;
+
+        assertFalse("unreachable runtime should report unhealthy, not throw", this.client.isHealthy());
+    }
+
+    // ==================== isReady ====================
+
+    public void testIsReadyReturnsTrueWhenReady() throws Exception {
+        startServer();
+        stub("/v1/ready", 200, "ready");
+        this.client = clientForServer(null);
+
+        assertTrue("ready runtime should report ready", this.client.isReady());
+    }
+
+    public void testIsReadyReturnsFalseWhileStillLoading() throws Exception {
+        startServer();
+        stub("/v1/ready", 503, "not ready");
+        this.client = clientForServer(null);
+
+        assertFalse("a loading runtime should not report ready", this.client.isReady());
+    }
+
+    // Building a client with an API key eagerly handshakes against Flight, so the
+    // authenticated paths are covered at the request-building level instead.
+
+    public void testProbeRequestSendsApiKeyWhenConfigured() throws Exception {
+        HttpRequest request = SpiceClient.buildProbeRequest(
+                new URI("http://127.0.0.1:8090"), "/v1/ready", "test-app|test-key");
+
+        assertEquals("http://127.0.0.1:8090/v1/ready", request.uri().toString());
+        assertEquals("the API key should be sent, as Spice.ai Cloud requires",
+                "test-app|test-key", request.headers().firstValue("X-API-Key").orElse(null));
+    }
+
+    public void testProbeRequestOmitsApiKeyWhenAbsent() throws Exception {
+        HttpRequest request = SpiceClient.buildProbeRequest(
+                new URI("http://127.0.0.1:8090"), "/health", null);
+
+        assertFalse("/health is unauthenticated",
+                request.headers().firstValue("X-API-Key").isPresent());
+        assertTrue("the user agent identifies the SDK",
+                request.headers().firstValue("X-Spice-User-Agent").isPresent());
+        assertEquals("GET", request.method());
+    }
+
+    // ==================== runtimeStatus ====================
+
+    public void testRuntimeStatusParsesAllConnections() throws Exception {
+        startServer();
+        stub("/v1/status", 200, "["
+                + "{\"name\":\"http\",\"endpoint\":\"127.0.0.1:8090\",\"status\":\"Ready\"},"
+                + "{\"name\":\"flight\",\"endpoint\":\"127.0.0.1:50051\",\"status\":\"Initializing\"},"
+                + "{\"name\":\"metrics\",\"endpoint\":\"N/A\",\"status\":\"Disabled\"},"
+                + "{\"name\":\"opentelemetry\",\"endpoint\":\"127.0.0.1:4317\",\"status\":\"Error\"}"
+                + "]");
+        this.client = clientForServer(null);
+
+        List<ConnectionDetails> status = this.client.runtimeStatus();
+
+        assertEquals(4, status.size());
+
+        assertEquals("http", status.get(0).getName());
+        assertEquals("127.0.0.1:8090", status.get(0).getEndpoint());
+        assertEquals(ComponentStatus.READY, status.get(0).getStatus());
+        assertTrue(status.get(0).isReady());
+
+        assertEquals(ComponentStatus.INITIALIZING, status.get(1).getStatus());
+        assertFalse("an initializing component is not ready", status.get(1).isReady());
+
+        assertEquals(ComponentStatus.DISABLED, status.get(2).getStatus());
+        assertEquals("N/A", status.get(2).getEndpoint());
+
+        assertEquals(ComponentStatus.ERROR, status.get(3).getStatus());
+        assertTrue(status.get(3).getStatus().isError());
+    }
+
+    public void testRuntimeStatusThrowsOnErrorStatusCode() throws Exception {
+        startServer();
+        stub("/v1/status", 500, "Error converting to CSV");
+        this.client = clientForServer(null);
+
+        try {
+            this.client.runtimeStatus();
+            fail("a 500 should raise");
+        } catch (ExecutionException e) {
+            assertTrue("the message should carry the status code",
+                    e.getMessage().contains("500"));
+        }
+    }
+
+    public void testRuntimeStatusReportsUnreachableRuntimeClearly() throws Exception {
+        startServer();
+        this.client = clientForServer(null);
+        int port = this.server.getAddress().getPort();
+        this.server.stop(0);
+        this.server = null;
+
+        try {
+            this.client.runtimeStatus();
+            fail("an unreachable runtime should raise");
+        } catch (ExecutionException e) {
+            // The message should tell the user what to fix, not leak a stack internal.
+            assertTrue("the message should name the address: " + e.getMessage(),
+                    e.getMessage().contains(String.valueOf(port)));
+        }
+    }
+
+    // ==================== parseRuntimeStatus ====================
+
+    public void testParseRuntimeStatusOnEmptyArray() throws Exception {
+        assertTrue(SpiceClient.parseRuntimeStatus("[]").isEmpty());
+    }
+
+    public void testParseRuntimeStatusToleratesMissingMembers() throws Exception {
+        List<ConnectionDetails> status = SpiceClient.parseRuntimeStatus("[{\"name\":\"http\"}]");
+
+        assertEquals(1, status.size());
+        assertEquals("http", status.get(0).getName());
+        assertNull(status.get(0).getEndpoint());
+        assertEquals("an absent status is unknown, not a crash",
+                ComponentStatus.UNKNOWN, status.get(0).getStatus());
+    }
+
+    public void testParseRuntimeStatusRejectsNonArray() {
+        try {
+            SpiceClient.parseRuntimeStatus("{\"name\":\"http\"}");
+            fail("a JSON object is not a valid status response");
+        } catch (ExecutionException e) {
+            assertTrue(e.getMessage().contains("unexpected status response"));
+        }
+    }
+
+    public void testParseRuntimeStatusRejectsMalformedJson() {
+        try {
+            SpiceClient.parseRuntimeStatus("not json at all {{{");
+            fail("malformed JSON should raise");
+        } catch (ExecutionException e) {
+            assertTrue(e.getMessage().contains("malformed status response"));
+        }
+    }
+
+    // ==================== ComponentStatus ====================
+
+    public void testComponentStatusFromWireValue() {
+        assertEquals(ComponentStatus.INITIALIZING, ComponentStatus.fromWireValue("Initializing"));
+        assertEquals(ComponentStatus.READY, ComponentStatus.fromWireValue("Ready"));
+        assertEquals(ComponentStatus.DISABLED, ComponentStatus.fromWireValue("Disabled"));
+        assertEquals(ComponentStatus.ERROR, ComponentStatus.fromWireValue("Error"));
+        assertEquals(ComponentStatus.REFRESHING, ComponentStatus.fromWireValue("Refreshing"));
+        assertEquals(ComponentStatus.SHUTTING_DOWN, ComponentStatus.fromWireValue("ShuttingDown"));
+        assertEquals(ComponentStatus.NOT_LOADED, ComponentStatus.fromWireValue("NotLoaded"));
+    }
+
+    public void testComponentStatusFallsBackToUnknown() {
+        // A newer runtime adding a status must not break an older client.
+        assertEquals(ComponentStatus.UNKNOWN, ComponentStatus.fromWireValue("SomethingNew"));
+        assertEquals(ComponentStatus.UNKNOWN, ComponentStatus.fromWireValue(null));
+    }
+
+    public void testComponentStatusPredicates() {
+        assertTrue(ComponentStatus.READY.isReady());
+        assertFalse(ComponentStatus.INITIALIZING.isReady());
+        assertTrue(ComponentStatus.ERROR.isError());
+        assertFalse(ComponentStatus.READY.isError());
+    }
+
+    public void testConnectionDetailsKeepsTheRawStatus() {
+        ConnectionDetails details = new ConnectionDetails("flight", "127.0.0.1:50051", "SomethingNew");
+
+        assertEquals(ComponentStatus.UNKNOWN, details.getStatus());
+        assertEquals("the verbatim value stays available", "SomethingNew", details.getRawStatus());
+        assertTrue(details.toString().contains("flight"));
+    }
+}


### PR DESCRIPTION
## What

Adds three runtime checks to `SpiceClient`, wrapping `/health`, `/v1/ready`, and `/v1/status`:

```java
// Liveness — unauthenticated.
if (!client.isHealthy()) {
    return;
}

// Readiness — a runtime can be healthy but still loading its datasets.
while (!client.isReady()) {
    Thread.sleep(1000);
}

// Per-component detail.
for (ConnectionDetails connection : client.runtimeStatus()) {
    System.out.printf("%s %s %s%n",
        connection.getName(), connection.getEndpoint(), connection.getStatus());
}
```

New public types: `ConnectionDetails` and `ComponentStatus`. Includes a runnable example at `src/main/java/ai/spice/example/ExampleHealthAndStatus.java`.

## Why

None of these were reachable from Java without hand-rolling the HTTP calls. Java was the only SDK missing health and readiness with no in-flight work covering it — gospice and spice.js already have them, and equivalents are open for spicepy (#173) and spice-rs (#81).

`/v1/status` is missing from every SDK, and is strictly more informative than the boolean `/v1/ready`: it names which connection is not ready and where it is bound.

Three design choices worth flagging for review:

- **The probes return `false` instead of throwing** when the runtime is unreachable, so they can be polled in a loop without a try/catch. `runtimeStatus()` does throw, since a caller asking for detail wants to know why it failed.
- **Naming** follows the `runtime_status` / `is_ready` convention that spicepy #173 and spice-rs #81 settled on, adapted to Java (`runtimeStatus()`, `isReady()`), rather than gospice's older `IsSpiceReady`.
- **An unrecognized status maps to `ComponentStatus.UNKNOWN`** rather than failing, so a newer runtime can add a status without breaking an older client. `getRawStatus()` returns it verbatim.

Also note: `isReady()` and `runtimeStatus()` send `X-API-Key` when an API key is configured, which Spice.ai Cloud requires. The existing `refreshDataset` does not — that looks like a separate bug and is left alone here.

## Verification

- [x] `mvn package -DskipTests` (with `-Dgpg.skip=true`; local signing has no key)
- [x] `mvn test` — 231 of 232 pass, including 18 new tests in `RuntimeStatusTest`. They run against a JDK `HttpServer` on an ephemeral port, so no live runtime and no new test dependency is needed.
- [x] `mvn spotbugs:check` — clean
- [x] Verified end to end against a live `spice run` by running the new
      `ExampleHealthAndStatus`:

```
Spice runtime is healthy
Spice runtime is ready
Runtime status:
  http           127.0.0.1:8090           Ready
  flight         127.0.0.1:50051          Ready
  metrics        N/A                      Disabled
  opentelemetry  127.0.0.1:50051          Ready
```

      Note the `metrics` row — `N/A` / `Disabled` is exactly the case a boolean
      readiness check cannot express, and it parses correctly.

The single failure, `ResetTest.testQueryAfterResetRebuildsClient` ("Expected a connection/transport error, got: Please add arrow-compression module ... LZ4_FRAME"), reproduces on unmodified `trunk` and is unrelated to this change.
