### PR TITLE
ci: define the test dataset inline instead of fetching it from the registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spiced &> spice.log &
           # time to initialize added dataset
           sleep 10
@@ -78,7 +91,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          @'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          '@ | Add-Content -Path spicepod.yaml
           Start-Process -FilePath spice run
           # time to initialize added dataset
           Start-Sleep -Seconds 10
@@ -169,7 +195,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spice run &> spice.log &
           # time to initialize added dataset
           sleep 10

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,7 +51,20 @@ jobs:
         run: |
           spice init spice_qs
           cd spice_qs
-          spice add spiceai/quickstart
+          # Define the dataset inline rather than fetching spiceai/quickstart from
+          # the Spicepod registry, which currently returns a body the CLI cannot
+          # unpack ("Failed to extract Spicepod archive: Could not find EOCD").
+          cat >> spicepod.yaml <<'YAML'
+
+          datasets:
+            - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+              name: taxi_trips
+              description: taxi trips in s3
+              params:
+                file_format: parquet
+              acceleration:
+                enabled: true
+          YAML
           spice run &> spice.log &
           # time to initialize added dataset
           sleep 10


### PR DESCRIPTION
## What

Replaces `spice add spiceai/quickstart` with the same dataset declared inline. Four sites: three in `build.yaml` (including the PowerShell step) and one in `publish.yaml`.

## Why

Every build job dies before Maven runs:

```
Getting Spicepod spiceai/quickstart ...
ERROR Invalid argument: Failed to extract Spicepod archive: invalid Zip archive: Could not find EOCD
##[error]Process completed with exit code 1
```

The Spicepod registry is returning a body the CLI can't unpack — reproducible off CI, so not a runner or network quirk. Pulling a test fixture from a remote registry means every PR depends on that service being up.

`publish.yaml` is included because it does the same fetch; leaving it would break the next release the same way.

Mirrors [spicepy#176](https://github.com/spiceai/spicepy/pull/176), which is green.

## Verification

- [x] Ran the resulting spicepod against a local runtime — `taxi_trips` queryable in ~6s, 2,964,624 rows
- [x] Both workflow files parse
- [x] Checked the dedented text each of the four steps actually hands its shell: heredoc for the bash steps, PowerShell here-string for the Windows step, terminator at column 0 in every case
- [x] `spice init` emits `version: v2`